### PR TITLE
Encodage des paramètres dans les urls

### DIFF
--- a/Library/TwinoidAPI.class.php
+++ b/Library/TwinoidAPI.class.php
@@ -12,15 +12,15 @@ class TwinoidAPI extends API
   //Récupère les informations de l'utilisateur actuellement connecté
   public function getMe($fields = "id,name,picture,locale,title,oldNames,sites,like,gender,birthday,city,country,desc,status,contacts,groups,devApps")
   {
-    $url = self::URL."me?fields=".$fields."&access_token=".$this->_token."";
-    
+    $url = self::URL."me?fields=".rawurlencode($fields)."&access_token=".$this->_token."";
+
     return $this->jsonCall($url);
   }
 
   //Récupère les informations d'un utilisateur spécifié
   public function getUser($userId, $fields = "id,name,picture,locale,title,oldNames,sites,like,gender,birthday,city,country,desc,status")
   {
-    $url = self::URL."user/".$userId."?fields=".$fields."&access_token=".$this->_token."";
+    $url = self::URL."user/".$userId."?fields=".rawurlencode($fields)."&access_token=".$this->_token."";
     
     return $this->jsonCall($url);
   }


### PR DESCRIPTION
Utiliser des parenthèses dans les url peut poser problème c'est pourquoi il faudrait encoder les paramètres. Il faudrait le faire sur toutes les fonctions à moins de factoriser le code des classes API.
